### PR TITLE
add --icon support

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,9 +109,22 @@ module.exports = function packager (opts, cb) {
         var finalPath = path.join(opts.out || process.cwd(), opts.name + '.app')
 
         fs.rename(newApp, finalPath, function moved (err) {
-          cb(err, finalPath)
+          if (err) return cb(err)
+          updateMacIcon()
         })
       }
+    })
+  }
+
+  function updateMacIcon () {
+    var finalPath = path.join(opts.out || process.cwd(), opts.name + '.app')
+
+    if (!opts.icon) {
+      return cb(null, finalPath)
+    }
+
+    ncp(opts.icon, path.join(finalPath, 'Contents', 'Resources', 'atom.icns'), function copied (err) {
+      cb(err, finalPath)
     })
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ these are optional CLI options you can pass in
 
 - `out` (default current working dir) - the dir to put the app into at the end
 - `version` (default hardcoded in source) - atom-shell version to use
+- `icon` - the icon file to use as the icon for the app
 - `app-bundle-id` - bundle identifier to use in the app plist
 - `helper-bundle-id` - bundle identifier to use in the app helper plist
 - `ignore` (default none) - do not copy files into App whose filenames regex .match this string


### PR DESCRIPTION
You can now pass an `--icon` argument to set a custom app icon. This would fix #5 but, without icns converstion.

```
atom-shell-packager ./app AppName --icon==resources/app.icns
```