### PR TITLE
add --app-version support

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,12 +57,17 @@ module.exports = function packager (opts, cb) {
 
     var bundleId = opts['app-bundle-id'] || 'com.atom-shell.' + opts.name.toLowerCase()
     var bundleHelperId = opts['helper-bundle-id'] || 'com.atom-shell.' + opts.name.toLowerCase() + '.helper'
+    var appVersion = opts['app-version']
 
     pl1.CFBundleDisplayName = opts.name
     pl1.CFBundleIdentifier = bundleId
     pl1.CFBundleName = opts.name
     pl2.CFBundleIdentifier = bundleHelperId
     pl2.CFBundleName = opts.name
+
+    if (appVersion) {
+      pl1.CFBundleVersion = appVersion
+    }
 
     if (opts.protocols) {
       pl2.CFBundleURLTypes = pl1.CFBundleURLTypes = opts.protocols.map(function (protocol) {

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ these are optional CLI options you can pass in
 - `out` (default current working dir) - the dir to put the app into at the end
 - `version` (default hardcoded in source) - atom-shell version to use
 - `app-bundle-id` - bundle identifier to use in the app plist
+- `app-version` - version to set for the app
 - `helper-bundle-id` - bundle identifier to use in the app helper plist
 - `ignore` (default none) - do not copy files into App whose filenames regex .match this string
 - `prune` - runs `npm prune --production` on the app


### PR DESCRIPTION
You can now pass an `--version` argument to set the app version.
```
atom-shell-packager ./app AppName --app-version=1.0.0
```