### PR TITLE
Add asar to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,3 +49,4 @@ these are optional CLI options you can pass in
 - `helper-bundle-id` - bundle identifier to use in the app helper plist
 - `ignore` (default none) - do not copy files into App whose filenames regex .match this string
 - `prune` - runs `npm prune --production` on the app
+- `asar` - packages the source code within your app into an archive


### PR DESCRIPTION
Forgot to add the `asar` option to the readme. Thanks!