### PR TITLE
Validate the --arch argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,12 @@ module.exports = function packager (opts, cb) {
 
   if (!platform || !arch || !version) cb(new Error('Must specify platform, arch and version'))
 
+  switch (arch) {
+    case 'ia32': break
+    case 'x64': break
+    default: cb(new Error('Unsupported arch'))
+  }
+
   switch (platform) {
     case 'darwin': packager = mac; break
     case 'linux': packager = linux; break


### PR DESCRIPTION
Currently electron-packager tries to download the electron archive with the given arch, no matter if the arch is valid or not.