### PR TITLE
Ignore this and related modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ module.exports = function packager (opts, cb) {
     default: return cb(new Error('Unsupported platform. Must be either darwin, linux, or win32'))
   }
 
+  // Ignore this and related modules by default
+  var default_ignores = ['node_modules/electron-prebuilt', 'node_modules/electron-packager', '.git']
+  if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
+  opts.ignore = (opts.ignore) ? opts.ignore.concat(default_ignores) : default_ignores
+
   download({
     platform: platform,
     arch: arch,


### PR DESCRIPTION
Regardless of what the outcome in https://github.com/maxogden/electron-packager/issues/13 will be. I think we should ignore what @sindresorhus first suggested, the module itself and the related `electron-prebuilt` and even `.git`.

:construction_worker: