### PR TITLE
symlink dereference added

### DIFF
--- a/linux.js
+++ b/linux.js
@@ -29,7 +29,7 @@ module.exports = {
 
     function copyUserApp () {
       var ncpOpts = {
-        dereference : opts.dereference || false,
+        dereference: opts.dereference || false,
         filter: userFilter
       }
       ncp(opts.dir, userAppDir, ncpOpts, function copied (err) {

--- a/linux.js
+++ b/linux.js
@@ -28,7 +28,11 @@ module.exports = {
     }
 
     function copyUserApp () {
-      ncp(opts.dir, userAppDir, {filter: userFilter}, function copied (err) {
+      var ncpOpts = {
+        dereference : opts.dereference || false,
+        filter: userFilter
+      }
+      ncp(opts.dir, userAppDir, ncpOpts, function copied (err) {
         if (err) return cb(err)
         if (opts.prune) {
           prune(function pruned (err) {

--- a/mac.js
+++ b/mac.js
@@ -78,12 +78,10 @@ function buildMacApp (opts, cb, newApp) {
     }
     return true
   }
-
-    var ncpOpts = {
-      dereference : opts.dereference || false,
-      filter: filter
-    }
-
+  var ncpOpts = {
+    dereference: opts.dereference || false,
+    filter: filter
+  }
   // copy users app into .app
   ncp(opts.dir, paths.app, ncpOpts, function copied (err) {
     if (err) return cb(err)

--- a/mac.js
+++ b/mac.js
@@ -79,8 +79,13 @@ function buildMacApp (opts, cb, newApp) {
     return true
   }
 
+    var ncpOpts = {
+      dereference : opts.dereference || false,
+      filter: filter
+    }
+
   // copy users app into .app
-  ncp(opts.dir, paths.app, {filter: filter}, function copied (err) {
+  ncp(opts.dir, paths.app, ncpOpts, function copied (err) {
     if (err) return cb(err)
 
     if (opts.prune) {

--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,11 @@ helper-bundle-id   bundle identifier to use in the app helper plist
 ignore             do not copy files into App whose filenames regex .match this string
 prune              runs `npm prune --production` on the app
 asar               packages the source code within your app into an archive
+deference          If set to true, the build will follow symbolic links. For example, a symlink in the source tree pointing to a regular file will become a regular file in the destination tree.
 sign               should contain the identity to be used when running `codesign` (OS X only)
 ```
+
+
 
 This will:
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ helper-bundle-id   bundle identifier to use in the app helper plist
 ignore             do not copy files into App whose filenames regex .match this string
 prune              runs `npm prune --production` on the app
 asar               packages the source code within your app into an archive
-dereference          If set to true, the build will follow symbolic links. For example, a symlink in the source tree pointing to a regular file will become a regular file in the destination tree.
+dereference        If set to true, the build will follow symbolic links. For example, a symlink in the source tree pointing to a regular file will become a regular file in the destination tree.
 sign               should contain the identity to be used when running `codesign` (OS X only)
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ helper-bundle-id   bundle identifier to use in the app helper plist
 ignore             do not copy files into App whose filenames regex .match this string
 prune              runs `npm prune --production` on the app
 asar               packages the source code within your app into an archive
-deference          If set to true, the build will follow symbolic links. For example, a symlink in the source tree pointing to a regular file will become a regular file in the destination tree.
+dereference          If set to true, the build will follow symbolic links. For example, a symlink in the source tree pointing to a regular file will become a regular file in the destination tree.
 sign               should contain the identity to be used when running `codesign` (OS X only)
 ```
 

--- a/win32.js
+++ b/win32.js
@@ -13,6 +13,7 @@ module.exports = {
   createApp: function createApp (opts, electronApp, cb) {
     var tmpDir = path.join(os.tmpdir(), 'electron-packager-windows')
 
+
     var newApp = path.join(tmpDir, opts.name + '-win32')
     // reset build folders + copy template app
     rimraf(tmpDir, function rmrfd () {
@@ -61,8 +62,13 @@ function buildWinApp (opts, cb, newApp) {
     return true
   }
 
+    var ncpOpts = {
+      dereference : opts.dereference || false,
+      filter: filter
+    }
+
   // copy users app into .app
-  ncp(opts.dir, paths.app, {filter: filter}, function copied (err) {
+  ncp(opts.dir, paths.app, ncpOpts, function copied (err) {
     if (err) return cb(err)
 
     if (opts.prune) {

--- a/win32.js
+++ b/win32.js
@@ -61,12 +61,10 @@ function buildWinApp (opts, cb, newApp) {
     }
     return true
   }
-
-    var ncpOpts = {
-      dereference : opts.dereference || false,
-      filter: filter
-    }
-
+  var ncpOpts = {
+    dereference: opts.dereference || false,
+    filter: filter
+  }
   // copy users app into .app
   ncp(opts.dir, paths.app, ncpOpts, function copied (err) {
     if (err) return cb(err)


### PR DESCRIPTION
Hi, 
  This pull request adds a new option `dereference` which is passed to the `options.dereference` in https://github.com/AvianFlu/ncp. This allows the build to copy symlinked resources as regular resources to the final directory.

This is very helpful when you have your `node_modules` and `bower_components` are symlinked from the other directories. 

Default value is `false` as `ncp`