### PR TITLE
fix defaultIgnores to be proper reg-exps

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function packager (opts, cb) {
   }
 
   // Ignore this and related modules by default
-  var defaultIgnores = ['node_modules/electron-prebuilt', 'node_modules/electron-packager', '.git']
+  var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\.git($|/)']
   if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
   opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
 


### PR DESCRIPTION
this fixes my case mentioned in https://github.com/maxogden/electron-packager/issues/44 - i had my project in a folder `/Users/zaggino/github/brackets-electron/` and `.git` matched the `/github` part