### PR TITLE
merge filter functions into one and make it project relative

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 var fs = require('fs')
+var path = require('path')
 var args = require('minimist')(process.argv.slice(2), {boolean: ['prune', 'asar']})
 var packager = require('./')
 var usage = fs.readFileSync(__dirname + '/usage.txt').toString()
 
-args.dir = args._[0]
+args.dir = path.resolve(args._[0])
 args.name = args._[1]
 
 var protocolSchemes = [].concat(args.protocol || [])

--- a/index.js
+++ b/index.js
@@ -32,9 +32,32 @@ module.exports = function packager (opts, cb) {
   }
 
   // Ignore this and related modules by default
-  var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\.git($|/)']
+  var defaultIgnores = [
+    '(^|/)\.git$',
+    '^node_modules/electron-prebuilt$',
+    '^node_modules/electron-packager$',
+    '^node_modules/electron-rebuild$'
+  ]
   if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
   opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
+
+  opts.ignoreFilter = function (file) {
+    // strip the fromDir from the file path
+    file = file.substring(opts.dir.length + 1)
+
+    // convert slashes so unix-format ignores work
+    file = file.replace(/\\/g, '/')
+
+    var ignore = opts.ignore || []
+    if (!Array.isArray(ignore)) ignore = [ignore]
+    for (var i = 0; i < ignore.length; i++) {
+      if (file.match(ignore[i])) {
+        console.log('Ignoring:', file)
+        return false
+      }
+    }
+    return true
+  }
 
   download({
     platform: platform,

--- a/linux.js
+++ b/linux.js
@@ -28,7 +28,7 @@ module.exports = {
     }
 
     function copyUserApp () {
-      ncp(opts.dir, userAppDir, {filter: userFilter, dereference: true}, function copied (err) {
+      ncp(opts.dir, userAppDir, {filter: opts.ignoreFilter, dereference: true}, function copied (err) {
         if (err) return cb(err)
         if (opts.prune) {
           prune(function pruned (err) {
@@ -58,18 +58,6 @@ module.exports = {
 
     function appFilter (file) {
       return file.match(/default_app/) === null
-    }
-
-    function userFilter (file) {
-      var ignore = opts.ignore || []
-      if (!Array.isArray(ignore)) ignore = [ignore]
-      ignore = ignore.concat([finalDir])
-      for (var i = 0; i < ignore.length; i++) {
-        if (file.match(ignore[i])) {
-          return false
-        }
-      }
-      return true
     }
 
     function asarApp (cb) {

--- a/mac.js
+++ b/mac.js
@@ -68,19 +68,8 @@ function buildMacApp (opts, cb, newApp) {
   fs.writeFileSync(paths.info1, plist.build(pl1))
   fs.writeFileSync(paths.info2, plist.build(pl2))
 
-  function filter (file) {
-    var ignore = opts.ignore || []
-    if (!Array.isArray(ignore)) ignore = [ignore]
-    for (var i = 0; i < ignore.length; i++) {
-      if (file.match(ignore[i])) {
-        return false
-      }
-    }
-    return true
-  }
-
   // copy users app into .app
-  ncp(opts.dir, paths.app, {filter: filter, dereference: true}, function copied (err) {
+  ncp(opts.dir, paths.app, {filter: opts.ignoreFilter, dereference: true}, function copied (err) {
     if (err) return cb(err)
 
     if (opts.prune) {

--- a/win32.js
+++ b/win32.js
@@ -50,22 +50,8 @@ function buildWinApp (opts, cb, newApp) {
     app: path.join(newApp, 'resources', 'app')
   }
 
-  function filter (file) {
-    // convert slashes so unix-format ignores work
-    file = file.replace(/\\/g, '/')
-
-    var ignore = opts.ignore || []
-    if (!Array.isArray(ignore)) ignore = [ignore]
-    for (var i = 0; i < ignore.length; i++) {
-      if (file.match(ignore[i])) {
-        return false
-      }
-    }
-    return true
-  }
-
   // copy users app into .app
-  ncp(opts.dir, paths.app, {filter: filter, dereference: true}, function copied (err) {
+  ncp(opts.dir, paths.app, {filter: opts.ignoreFilter, dereference: true}, function copied (err) {
     if (err) return cb(err)
 
     if (opts.prune) {


### PR DESCRIPTION
For the reasons described in https://github.com/maxogden/electron-packager/issues/44

Before the change the ignore string were treated as regexp matched against full file paths

After the change the ignore strings are treated as regexps but matched against relative file paths