### PR TITLE
Version info added to the final executable using rcedit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,17 @@ ignore             do not copy files into App whose filenames regex .match this 
 prune              runs `npm prune --production` on the app
 asar               packages the source code within your app into an archive
 sign               should contain the identity to be used when running `codesign` (OS X only)
+version-string     should contain a hash of the application metadata to be embedded into the executable (Windows only). Keys supported
+                   - CompanyName
+                   - LegalCopyright
+                   - FileDescription
+                   - OriginalFilename
+                   - FileVersion
+                   - ProductVersion
+                   - ProductName
+                   - InternalName
+                   
+
 ```
 
 This will:

--- a/win32.js
+++ b/win32.js
@@ -73,7 +73,7 @@ function buildWinApp (opts, cb, newApp) {
     function updateResourceData () {
       var finalPath = path.join(opts.out || process.cwd(), opts.name + '-win32')
 
-      if (!opts.icon) {
+      if (!opts.icon && !opts['version-string']) {
         return cb(null, finalPath)
       }
 

--- a/win32.js
+++ b/win32.js
@@ -62,15 +62,15 @@ function buildWinApp (opts, cb, newApp) {
           var finalPath = path.join(opts.out || process.cwd(), opts.name + '-win32', 'resources')
           common.asarApp(finalPath, function (err) {
             if (err) return cb(err)
-            updateIcon()
+            updateResourceData()
           })
         } else {
-          updateIcon()
+          updateResourceData()
         }
       })
     }
 
-    function updateIcon () {
+    function updateResourceData () {
       var finalPath = path.join(opts.out || process.cwd(), opts.name + '-win32')
 
       if (!opts.icon) {
@@ -78,8 +78,11 @@ function buildWinApp (opts, cb, newApp) {
       }
 
       var exePath = path.join(opts.out || process.cwd(), opts.name + '-win32', opts.name + '.exe')
-
-      rcedit(exePath, {icon: opts.icon}, function (err) {
+      var rcOptions = {
+        icon: opts.icon,
+        'version-string': opts['version-string']
+      }
+      rcedit(exePath, rcOptions, function (err) {
         cb(err, finalPath)
       })
     }


### PR DESCRIPTION
This PR fixes the following issue `Set product name, file description copyright on Windows`
    https://github.com/maxogden/electron-packager/issues/30

As per the comment https://github.com/maxogden/electron-packager/issues/30#issuecomment-111472208 by @felicienfrancois, `rcedit`  is already doing it. 

This patch has following changes
- User need to pass `version-string` hash in the options. THis has following fields
```
                   CompanyName
                   LegalCopyright
                   FileDescription
                   OriginalFilename
                   FileVersion
                   ProductVersion
                   ProductName
                   InternalName
```
- instead of passing just the icon to rcedit, now the version-string is also passed.

Below the sample grunt config
```
   electron:{
    win : {
      options: {
        name : 'Fresenius',
        dir : 'build/',
        out : 'package/app/win32',
        version : '0.25.3',
        platform: 'win32',
        arch : 'x64',
        icon : 'app/static/assets/icon.ico',
        'version-string': {
          'CompanyName': 'Pocketworks UK.',
          'LegalCopyright': 'Copyright 2015 Pocketworks UK. All rights reserved."',
          'FileDescription' : 'Fresenius',
          'OriginalFilename' : 'Fresenius.exe',
          'FileVersion' : '0.0.1',
          'ProductVersion' : '0.0.1',
          'ProductName' : 'Fresenius',
          'InternalName' : 'Fresenius.exe'
        }
      }
    }
  },
```

We dont need resourcehacker dependency after all..

Below screenshot is the output of above config.

![screen shot 2015-06-12 at 6 21 55 pm](https://cloud.githubusercontent.com/assets/750555/8130727/a67aab36-1132-11e5-9d15-ca96f538b7a7.png)
