### PR TITLE
Add quotes around signing identity to allow spaces

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -117,7 +117,7 @@ function buildMacApp (opts, cb, newApp) {
 
       if (!opts.sign) return cb(null, appPath)
 
-      child.exec('codesign --deep --force --sign ' + opts.sign + ' ' + appPath, function (err, stdout, stderr) {
+      child.exec('codesign --deep --force --sign "' + opts.sign + '" ' + appPath, function (err, stdout, stderr) {
         cb(err, appPath)
       })
     }


### PR DESCRIPTION
The packager strips quotes from the `--sign` argument, which makes using a more detailed signing identity (necesssary when having multiple identities for iPhone, Mac App Store and/or Deveoper ID) impossible.