### PR TITLE
Fix double resources in path when generating asar file on windows

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -35,7 +35,7 @@ function buildMacApp (opts, cb, newApp) {
   var paths = {
     info1: path.join(newApp, 'Contents', 'Info.plist'),
     info2: path.join(newApp, 'Contents', 'Frameworks', 'Electron Helper.app', 'Contents', 'Info.plist'),
-    app: path.join(newApp, 'Contents', 'Resources', 'resources', 'app' )
+    app: path.join(newApp, 'Contents', 'Resources', 'resources', 'app')
   }
 
   // update plist files

--- a/mac.js
+++ b/mac.js
@@ -35,7 +35,7 @@ function buildMacApp (opts, cb, newApp) {
   var paths = {
     info1: path.join(newApp, 'Contents', 'Info.plist'),
     info2: path.join(newApp, 'Contents', 'Frameworks', 'Electron Helper.app', 'Contents', 'Info.plist'),
-    app: path.join(newApp, 'Contents', 'Resources', 'app')
+    app: path.join(newApp, 'Contents', 'Resources', 'resources', 'app' )
   }
 
   // update plist files

--- a/win32.js
+++ b/win32.js
@@ -59,7 +59,7 @@ function buildWinApp (opts, cb, newApp) {
       copy(newApp, finalPath, function moved (err) {
         if (err) return cb(err)
         if (opts.asar) {
-          var finalPath = path.join(opts.out || process.cwd(), opts.name + '-win32', 'resources')
+          var finalPath = path.join(opts.out || process.cwd(), opts.name + '-win32')
           common.asarApp(finalPath, function (err) {
             if (err) return cb(err)
             updateIcon()


### PR DESCRIPTION
When building a windows electron package the `common.asarApp` method would get the following path: `c:\path\to\release\apps\MyApp-win32\resources`. `common.asarApp` appends `resources\app` resulting in an invalid path to the app folder.

The asar file was never generated due to the invalid paths.