### PR TITLE
Fix path separator replacement for ignore on Windows

### DIFF
--- a/common.js
+++ b/common.js
@@ -27,9 +27,9 @@ module.exports = {
     }
   },
 
-  userIgnoreFilter: function userIgnoreFilter (opts, is_win32, finalDir) {
+  userIgnoreFilter: function userIgnoreFilter (opts, finalDir) {
     return function filter (file) {
-      if (is_win32) {
+      if (path.sep === '\\') {
         // convert slashes so unix-format ignores work
         file = file.replace(/\\/g, '/')
       }

--- a/linux.js
+++ b/linux.js
@@ -26,7 +26,7 @@ module.exports = {
     }
 
     function copyUserApp () {
-      ncp(opts.dir, userAppDir, {filter: common.userIgnoreFilter(opts, false, finalDir), dereference: true}, function copied (err) {
+      ncp(opts.dir, userAppDir, {filter: common.userIgnoreFilter(opts, finalDir), dereference: true}, function copied (err) {
         if (err) return cb(err)
         common.prune(opts, userAppDir, cb, renameElectronBinary)
       })

--- a/win32.js
+++ b/win32.js
@@ -50,7 +50,7 @@ function buildWinApp (opts, cb, newApp) {
   }
 
   // copy users app into destination path
-  ncp(opts.dir, paths.app, {filter: common.userIgnoreFilter(opts, true), dereference: true}, function copied (err) {
+  ncp(opts.dir, paths.app, {filter: common.userIgnoreFilter(opts), dereference: true}, function copied (err) {
     if (err) return cb(err)
 
     function moveApp () {


### PR DESCRIPTION
This needs to be done when Windows is the host OS regardless of
the target platform, not vice versa.

Fixes #79.

Tested on Windows 7, OS X 10.10, and Xubuntu.