### PR TITLE
Adds CFBundleShortVersionString to the main .plist on OSX

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -33,6 +33,7 @@ module.exports = {
 
       if (appVersion) {
         appPlist.CFBundleVersion = appVersion
+        appPlist.CFBundleShortVersionString = appVersion
       }
 
       if (opts.protocols) {


### PR DESCRIPTION
Hi,

this PR adds the `CFBundleShortVersionString` key to the `.plist` file when building an OSX app.

This key is used when displaying the app version in the Finder.

Currently, without the key:

![vuplicity-darwin-x64 2015-07-02 15-24-05](https://cloud.githubusercontent.com/assets/5699295/8478204/1dc87702-20d0-11e5-85c5-04e4ff24280c.png)

With the key:

![vuplicity-darwin-x64 2015-07-02 15-24-05 copy](https://cloud.githubusercontent.com/assets/5699295/8478206/215a51f6-20d0-11e5-8861-afc259e795fe.png)

Thanks !