### PR TITLE
Rename ALL the helpers

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -95,7 +95,8 @@ module.exports = {
         })
       }
 
-      series(operations, function () {
+      series(operations, function (err) {
+        if (err) return callback(err)
         common.moveApp(opts, tempPath, callback)
       })
     })

--- a/mac.js
+++ b/mac.js
@@ -8,6 +8,25 @@ var ncp = require('ncp').ncp
 var series = require('run-series')
 var common = require('./common')
 
+function moveHelpers (frameworksPath, appName, callback) {
+  function rename (basePath, oldName, newName, cb) {
+    mv(path.join(basePath, oldName), path.join(basePath, newName), cb)
+  }
+
+  series([' Helper', ' Helper EH', ' Helper NP'].map(function (suffix) {
+    return function (cb) {
+      var executableBasePath = path.join(frameworksPath, 'Electron' + suffix + '.app', 'Contents', 'MacOS')
+
+      rename(executableBasePath, 'Electron' + suffix, appName + suffix, function (err) {
+        if (err) return cb(err)
+        rename(frameworksPath, 'Electron' + suffix + '.app', appName + suffix + '.app', cb)
+      })
+    }
+  }), function (err) {
+    callback(err)
+  })
+}
+
 module.exports = {
   createApp: function createApp (opts, templatePath, callback) {
     var appRelativePath = path.join('Electron.app', 'Contents', 'Resources', 'app')
@@ -15,9 +34,9 @@ module.exports = {
       if (err) return callback(err)
 
       var contentsPath = path.join(tempPath, 'Electron.app', 'Contents')
-      var helperPath = path.join(contentsPath, 'Frameworks', 'Electron Helper.app')
+      var frameworksPath = path.join(contentsPath, 'Frameworks')
       var appPlistFilename = path.join(contentsPath, 'Info.plist')
-      var helperPlistFilename = path.join(helperPath, 'Contents', 'Info.plist')
+      var helperPlistFilename = path.join(frameworksPath, 'Electron Helper.app', 'Contents', 'Info.plist')
       var appPlist = plist.parse(fs.readFileSync(appPlistFilename).toString())
       var helperPlist = plist.parse(fs.readFileSync(helperPlistFilename).toString())
 
@@ -62,13 +81,10 @@ module.exports = {
         })
       }
 
-      // Move Helper binary, then Helper.app, then top-level .app
+      // Move Helper apps/executables, then top-level .app
       var finalAppPath = path.join(tempPath, opts.name + '.app')
       operations.push(function (cb) {
-        var helperBinaryPath = path.join(helperPath, 'Contents', 'MacOS')
-        mv(path.join(helperBinaryPath, 'Electron Helper'), path.join(helperBinaryPath, opts.name + ' Helper'), cb)
-      }, function (cb) {
-        mv(helperPath, path.join(path.dirname(helperPath), opts.name + ' Helper.app'), cb)
+        moveHelpers(frameworksPath, opts.name, cb)
       }, function (cb) {
         mv(path.dirname(contentsPath), finalAppPath, cb)
       })

--- a/win32.js
+++ b/win32.js
@@ -32,7 +32,8 @@ module.exports = {
         })
       }
 
-      series(operations, function () {
+      series(operations, function (err) {
+        if (err) return callback(err)
         common.moveApp(opts, tempPath, callback)
       })
     })


### PR DESCRIPTION
This fixes #100 by renaming all 3 helper apps and their executables for OS X releases.  A new test is included.

This is a follow-up to #76, in which I'd only renamed the main helper app, because I wasn't seeing anything break even without renaming the other helpers, but #100 has proven otherwise.

There is one additional commit in this branch which fixes error reporting for win32 and darwin targets, which I apparently somehow goofed and missed in #88 I think.