### PR TITLE
fixes#101 pass --unpack argument to the asar option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - '0.12'
+cache:
+  directories:
+    - $HOME/.electron

--- a/common.js
+++ b/common.js
@@ -93,7 +93,7 @@ module.exports = {
 
     if (opts.asar) {
       operations.push(function (cb) {
-        var options = {};
+        var options = {}
         if (opts.asar_unpack) {
           options['unpack'] = opts.asar_unpack
         }

--- a/common.js
+++ b/common.js
@@ -9,10 +9,10 @@ var ncp = require('ncp').ncp
 var rimraf = require('rimraf')
 var series = require('run-series')
 
-function asarApp (appPath, cb) {
+function asarApp (appPath, asarOptions, cb) {
   var src = path.join(appPath)
   var dest = path.join(appPath, '..', 'app.asar')
-  asar.createPackage(src, dest, function (err) {
+  asar.createPackageWithOptions(src, dest, asarOptions, function (err) {
     if (err) return cb(err)
     rimraf(src, function (err) {
       if (err) return cb(err)
@@ -93,7 +93,14 @@ module.exports = {
 
     if (opts.asar) {
       operations.push(function (cb) {
-        asarApp(path.join(appPath), cb)
+        var options = {};
+        if (opts.asar_unpack) {
+          options['unpack'] = opts.asar_unpack
+        }
+        if (opts.asar_snapshot) {
+          options['snapshot'] = opts.asar_snapshot
+        }
+        asarApp(path.join(appPath), options, cb)
       })
     }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -117,7 +117,7 @@ function createAsarTest (combination) {
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.asar = true
-
+    opts.asar_unpack = '*.pac'
     var finalPath
     var resourcesPath
 
@@ -138,8 +138,11 @@ function createAsarTest (combination) {
         t.true(stats.isFile(), 'app.asar should exist under the resources subdirectory when opts.asar is true')
         fs.exists(path.join(resourcesPath, 'app'), function (exists) {
           t.false(exists, 'app subdirectory should NOT exist when app.asar is built')
-          cb()
         })
+        fs.stat(path.join(resourcesPath, 'app.asar.unpacked'), cb)
+      }, function (stats, cb) {
+        t.true(stats.isDirectory(), 'app.asar.unpacked should exist under the resources subdirectory when opts.asar_unpack is set some expression')
+        cb()
       }
     ], function (err) {
       t.end(err)

--- a/test/fixtures/basic/file_to_unpack.pac
+++ b/test/fixtures/basic/file_to_unpack.pac
@@ -1,0 +1,1 @@
+This file is used for testing asar unpack option


### PR DESCRIPTION
fixes#101 Integrated asar options for unpack and snapshot.

`unpack` can be used by passing the flag `--asar_unpack`

Similarly `snapshot` option  can be passed with the flag `--asar_snapshot` 

Example usage,
```
electron-packager . my_app --out=dist --ignore=dist --prune --asar --asar_unpack=*.dylib --platform=darwin --arch=x64 --version=0.30.0 --overwrite
```

Have tested these features [here](https://github.com/krishnaIndia/dns_manager/blob/master/package.json#L21)