### PR TITLE
Add option to pass --unpack argument to asar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - '0.12'
+cache:
+  directories:
+    - $HOME/.electron

--- a/common.js
+++ b/common.js
@@ -93,7 +93,7 @@ module.exports = {
 
     if (opts.asar) {
       operations.push(function (cb) {
-        var options = {};
+        var options = {}
         if (opts.asar_unpack) {
           options['unpack'] = opts.asar_unpack
         }

--- a/common.js
+++ b/common.js
@@ -94,11 +94,8 @@ module.exports = {
     if (opts.asar) {
       operations.push(function (cb) {
         var options = {}
-        if (opts.asar_unpack) {
-          options['unpack'] = opts.asar_unpack
-        }
-        if (opts.asar_snapshot) {
-          options['snapshot'] = opts.asar_snapshot
+        if (opts['asar-unpack']) {
+          options['unpack'] = opts['asar-unpack']
         }
         asarApp(path.join(appPath), options, cb)
       })

--- a/common.js
+++ b/common.js
@@ -9,10 +9,10 @@ var ncp = require('ncp').ncp
 var rimraf = require('rimraf')
 var series = require('run-series')
 
-function asarApp (appPath, cb) {
+function asarApp (appPath, asarOptions, cb) {
   var src = path.join(appPath)
   var dest = path.join(appPath, '..', 'app.asar')
-  asar.createPackage(src, dest, function (err) {
+  asar.createPackageWithOptions(src, dest, asarOptions, function (err) {
     if (err) return cb(err)
     rimraf(src, function (err) {
       if (err) return cb(err)
@@ -93,7 +93,14 @@ module.exports = {
 
     if (opts.asar) {
       operations.push(function (cb) {
-        asarApp(path.join(appPath), cb)
+        var options = {};
+        if (opts.asar_unpack) {
+          options['unpack'] = opts.asar_unpack
+        }
+        if (opts.asar_snapshot) {
+          options['snapshot'] = opts.asar_snapshot
+        }
+        asarApp(path.join(appPath), options, cb)
       })
     }
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ ignore             do not copy files into App whose filenames regex .match this 
 prune              runs `npm prune --production` on the app
 overwrite          if output directory for a platform already exists, replaces it rather than skipping it
 asar               packages the source code within your app into an archive
+asar-unpack        unpacks the files to app.asar.unpacked directory whose filenames regex .match this string
 sign               should contain the identity to be used when running `codesign` (OS X only)
 version-string     should contain a hash of the application metadata to be embedded into the executable (Windows only).
                    These can be specified on the command line via dot notation,
@@ -120,6 +121,8 @@ Shortcut for `--arch=all --platform=all`
 `overwrite` - *Boolean*
 
 `asar` - *Boolean*
+
+`asar-unpack` - *String*
 
 `sign` - *String*
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -117,7 +117,7 @@ function createAsarTest (combination) {
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.asar = true
-    opts.asar_unpack = '*.pac'
+    opts['asar-unpack'] = '*.pac'
     var finalPath
     var resourcesPath
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -117,7 +117,7 @@ function createAsarTest (combination) {
     opts.name = 'basicTest'
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.asar = true
-
+    opts.asar_unpack = '*.pac'
     var finalPath
     var resourcesPath
 
@@ -138,8 +138,11 @@ function createAsarTest (combination) {
         t.true(stats.isFile(), 'app.asar should exist under the resources subdirectory when opts.asar is true')
         fs.exists(path.join(resourcesPath, 'app'), function (exists) {
           t.false(exists, 'app subdirectory should NOT exist when app.asar is built')
-          cb()
         })
+        fs.stat(path.join(resourcesPath, 'app.asar.unpacked'), cb)
+      }, function (stats, cb) {
+        t.true(stats.isDirectory(), 'app.asar.unpacked should exist under the resources subdirectory when opts.asar_unpack is set some expression')
+        cb()
       }
     ], function (err) {
       t.end(err)

--- a/test/fixtures/basic/file_to_unpack.pac
+++ b/test/fixtures/basic/file_to_unpack.pac
@@ -1,0 +1,1 @@
+This file is used for testing asar unpack option

--- a/usage.txt
+++ b/usage.txt
@@ -21,6 +21,7 @@ ignore             do not copy files into App whose filenames regex .match this 
 prune              runs `npm prune --production` on the app
 overwrite          if output directory for a platform already exists, replaces it rather than skipping it
 asar               packages the source code within your app into an archive
+asar-unpack        unpacks the files to app.asar.unpacked directory whose filenames regex .match this string
 sign               should contain the identity to be used when running `codesign` (OS X only)
 version-string     should contain a hash of the application metadata to be embedded into the executable (Windows only).
                    These can be specified on the command line via dot notation,


### PR DESCRIPTION
fixes #101 Integrated asar options for unpack and snapshot.

unpack can be used by passing the flag --asar-unpack

This option would enable users to unpack files to `app.asar.unpacked` directory. asar-unpack accepts regex string for referring the files to be unpacked