### PR TITLE
Add build version number for OSX

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -43,6 +43,7 @@ module.exports = {
       // Update plist files
       var defaultBundleName = 'com.electron.' + opts.name.toLowerCase().replace(/ /g, '_')
       var appVersion = opts['app-version']
+      var buildVersion = opts['build-version']
 
       appPlist.CFBundleDisplayName = opts.name
       appPlist.CFBundleIdentifier = opts['app-bundle-id'] || defaultBundleName
@@ -51,7 +52,11 @@ module.exports = {
       helperPlist.CFBundleName = opts.name
 
       if (appVersion) {
-        appPlist.CFBundleVersion = appVersion
+        appPlist.CFBundleShortVersionString = appPlist.CFBundleVersion = appVersion
+      }
+
+      if (buildVersion) {
+        appPlist.CFBundleVersion = buildVersion
       }
 
       if (opts.protocols) {

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,8 @@ all                equivalent to --platform=all --arch=all
 out                the dir to put the app into at the end. defaults to current working dir
 icon               the icon file to use as the icon for the app
 app-bundle-id      bundle identifier to use in the app plist
-app-version        version to set for the app
+app-version        release version to set for the app
+build-version      build version to set for the app (OS X only)
 cache              directory of cached electron downloads. Defaults to '$HOME/.electron'
 helper-bundle-id   bundle identifier to use in the app helper plist
 ignore             do not copy files into App whose filenames regex .match this string


### PR DESCRIPTION
Like in #93 i need to add the release and build version number for my OSX app. Unfortunately that PR wouldn't solve my problem cause i need to add a different build version.

Also the `app-version` is stored in the `CFBundleVersion ` property which is, according to [Apple](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html), meant to store the build version number, whereas the `CFBundleShortVersionString ` stores the actual release version. I would suggest to store the `app-version` in `CFBundleShortVersionString` and the new `build-version` in `CFBundleVersion`.

Besides that great project. Whole setup worked like a charm. 