### PR TITLE
Fixate dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,17 +17,17 @@
   },
   "homepage": "https://github.com/maxogden/electron-packager",
   "dependencies": {
-    "asar": "^0.6.1",
-    "electron-download": "^1.0.0",
-    "extract-zip": "^1.0.3",
-    "minimist": "^1.1.1",
-    "mkdirp": "^0.5.0",
-    "mv": "^2.0.3",
-    "ncp": "^2.0.0",
-    "plist": "^1.1.0",
-    "rcedit": "^0.3.0",
-    "rimraf": "^2.3.2",
-    "run-series": "^1.1.1"
+    "asar": "0.6.1",
+    "electron-download": "1.0.0",
+    "extract-zip": "1.0.3",
+    "minimist": "1.1.1",
+    "mkdirp": "0.5.0",
+    "mv": "2.0.3",
+    "ncp": "2.0.0",
+    "plist": "1.1.0",
+    "rcedit": "0.3.0",
+    "rimraf": "2.3.2",
+    "run-series": "1.1.1"
   },
   "devDependencies": {
     "run-waterfall": "^1.1.1",


### PR DESCRIPTION
Otherwise sub dependencies break frequently, which breaks builds on platforms randomly (which is the case with linux/windows builds with latest version as of today, but was working 2 days ago, and only thing changed were minor sub dependency versions).

This PR fixes deps to their original versions, which I've verified to work on all platforms in our build system.