### PR TITLE
Fix #129: support file-version metadata (win32)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ node_js:
 cache:
   directories:
     - $HOME/.electron
+addons:
+  apt:
+    packages:
+    - wine

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "devDependencies": {
     "run-waterfall": "^1.1.1",
     "standard": "^3.3.2",
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "rcinfo": "^0.1.3"
   },
   "scripts": {
     "test": "standard && tape test"

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ series([
   console.log('Running tests...')
   require('./basic')
   require('./multitarget')
+  require('./win32')
 
   if (process.platform !== 'win32') {
     // Perform additional tests specific to building for OS X

--- a/test/win32.js
+++ b/test/win32.js
@@ -1,0 +1,54 @@
+var fs = require('fs')
+var path = require('path')
+
+var packager = require('..')
+var test = require('tape')
+var waterfall = require('run-waterfall')
+
+var config = require('./config.json')
+var util = require('./util')
+
+var rcinfo = require('rcinfo')
+
+var baseOpts = {
+  name: 'basicTest',
+  dir: path.join(__dirname, 'fixtures', 'basic'),
+  version: config.version,
+  arch: 'x64',
+  platform: 'win32'
+}
+
+function setFileVersionTest (fileVersion) {
+  return function (t) {
+    t.timeoutAfter(config.timeout)
+
+    var appExePath
+    var opts = Object.create(baseOpts)
+    opts['version-string'] = {
+      FileVersion: fileVersion
+    }
+
+    waterfall([
+      function (cb) {
+        packager(opts, cb)
+      }, function (paths, cb) {
+        appExePath = path.join(paths[0], opts.name + '.exe')
+        fs.stat(appExePath, cb)
+      }, function (stats, cb) {
+        t.true(stats.isFile(), 'The expected EXE file should exist')
+        cb()
+      }, function (cb) {
+        rcinfo(appExePath, cb)
+      }, function (info, cb) {
+        t.equal(info.FileVersion, fileVersion, 'File version should match')
+        cb()
+      }
+    ], function (err) {
+      t.end(err)
+    })
+  }
+}
+
+util.setup()
+test('win32 file version test', setFileVersionTest('1.2.3.4'))
+util.teardown()

--- a/win32.js
+++ b/win32.js
@@ -20,7 +20,13 @@ module.exports = {
         operations.push(function (cb) {
           common.normalizeExt(opts.icon, '.ico', function (err, icon) {
             var rcOpts = {}
-            if (opts['version-string']) rcOpts['version-string'] = opts['version-string']
+            if (opts['version-string']) {
+              rcOpts['version-string'] = opts['version-string']
+
+              if (opts['version-string'].FileVersion) {
+                rcOpts['file-version'] = opts['version-string'].FileVersion
+              }
+            }
 
             // Icon might be omitted or only exist in one OS's format, so skip it if normalizeExt reports an error
             if (!err) {


### PR DESCRIPTION
I had trouble cleaning up my commit logs on previous pull request. I'm not sure how to put up a test for windows executable file version though.