### PR TITLE
Add `build-version` to opts documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,8 @@ If the file extension is omitted, it is auto-completed to the correct extension 
 
 `app-version` - *String*
 
+`build-version` - *String*
+
 `cache` - *String*
 
 `helper-bundle-id` - *String*


### PR DESCRIPTION
Hello,

I got a strange bug using Electron's auto-update that turned out to be because I set the `build-version` option as an number while it should be a string (https://github.com/atom/electron/issues/3067).

This PR simply adds this information to the readme.