### PR TITLE
Add that app-version is a mac-only option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ all                equivalent to --platform=all --arch=all
 out                the dir to put the app into at the end. defaults to current working dir
 icon               the icon file to use as the icon for the app. Note: Format depends on OS.
 app-bundle-id      bundle identifier to use in the app plist
-app-version        release version to set for the app
+app-version        release version to set for the app (OS X only)
 build-version      build version to set for the app (OS X only)
 cache              directory of cached electron downloads. Defaults to '$HOME/.electron'
 helper-bundle-id   bundle identifier to use in the app helper plist


### PR DESCRIPTION
From the source it looks like this is a mac-only feature