### PR TITLE
Support unpack directory

### DIFF
--- a/common.js
+++ b/common.js
@@ -97,6 +97,9 @@ module.exports = {
         if (opts['asar-unpack']) {
           options['unpack'] = opts['asar-unpack']
         }
+        if (opts['asar-unpack-dir']) {
+          options['unpackDir'] = opts['asar-unpack-dir']
+        }
         asarApp(path.join(appPath), options, cb)
       })
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/maxogden/electron-packager",
   "dependencies": {
-    "asar": "^0.6.1",
+    "asar": "^0.8.2",
     "electron-download": "^1.0.0",
     "extract-zip": "^1.0.3",
     "minimist": "^1.1.1",

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,9 @@ packager(opts, function done (err, appPath) { })
 
 `asar-unpack-dir` - *String*
 
+  Unpacks the dir to app.asar.unpacked directory whose names exactly match this string. The `asar-unpack-dir` is relative to `dir`.
+  For example, `asar-unpack-dir=sub_dir` will unpack the directory `/<dir>/sub_dir`.
+
 `build-version` - *String*
 
 `cache` - *String*

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,8 @@ packager(opts, function done (err, appPath) { })
 
 `asar-unpack` - *String*
 
+`asar-unpack-dir` - *String*
+
 `build-version` - *String*
 
 `cache` - *String*

--- a/test/basic.js
+++ b/test/basic.js
@@ -118,6 +118,7 @@ function createAsarTest (combination) {
     opts.dir = path.join(__dirname, 'fixtures', 'basic')
     opts.asar = true
     opts['asar-unpack'] = '*.pac'
+    opts['asar-unpack-dir'] = 'dir_to_unpack'
     var finalPath
     var resourcesPath
 
@@ -142,6 +143,9 @@ function createAsarTest (combination) {
         fs.stat(path.join(resourcesPath, 'app.asar.unpacked'), cb)
       }, function (stats, cb) {
         t.true(stats.isDirectory(), 'app.asar.unpacked should exist under the resources subdirectory when opts.asar_unpack is set some expression')
+        fs.stat(path.join(resourcesPath, 'app.asar.unpacked', 'dir_to_unpack'), cb)
+      }, function (stats, cb) {
+        t.true(stats.isDirectory(), 'dir_to_unpack should exist under app.asar.unpacked subdirectory when opts.asar-unpack-dir is set dir_to_unpack')
         cb()
       }
     ], function (err) {

--- a/usage.txt
+++ b/usage.txt
@@ -15,6 +15,7 @@ app-bundle-id      bundle identifier to use in the app plist (darwin platform on
 app-version        release version to set for the app
 asar               packages the source code within your app into an archive
 asar-unpack        unpacks the files to app.asar.unpacked directory whose filenames regex .match this string
+asar-unpack-dir    unpacks the dirs to app.asar.unpacked directory whose names match this string
 build-version      build version to set for the app (darwin platform only)
 cache              directory of cached Electron downloads. Defaults to '$HOME/.electron'
 helper-bundle-id   bundle identifier to use in the app helper plist (darwin platform only)

--- a/usage.txt
+++ b/usage.txt
@@ -15,7 +15,8 @@ app-bundle-id      bundle identifier to use in the app plist (darwin platform on
 app-version        release version to set for the app
 asar               packages the source code within your app into an archive
 asar-unpack        unpacks the files to app.asar.unpacked directory whose filenames regex .match this string
-asar-unpack-dir    unpacks the dirs to app.asar.unpacked directory whose names match this string
+asar-unpack-dir    unpacks the dir to app.asar.unpacked directory whose names match this string. It's relative to the <sourcedir>.
+                   For example, `--asar-unpack-dir=sub_dir` will unpack the directory `/<sourcedir>/sub_dir`.
 build-version      build version to set for the app (darwin platform only)
 cache              directory of cached Electron downloads. Defaults to '$HOME/.electron'
 helper-bundle-id   bundle identifier to use in the app helper plist (darwin platform only)


### PR DESCRIPTION
The lastest version(v0.8.2) of asar supports unpack directory, atom/asar#44. It's resonable to implement on electron-packager. 

Fixes #171, and part of #114(We can unpack the `PepperFlashPlayer.plugin` directory on OS X).