### PR TITLE
Ignore node_modules/.bin by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ module.exports = function packager (opts, cb) {
   if (!Array.isArray(platforms)) return cb(new Error(platforms))
 
   // Ignore this and related modules by default
-  var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\.git($|/)']
+  var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\\.git($|/)', '/node_modules/\\.bin($|/)']
   if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
   opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
 

--- a/test/fixtures/basic/package.json
+++ b/test/fixtures/basic/package.json
@@ -4,7 +4,7 @@
     "run-series": "^1.1.1"
   },
   "devDependencies": {
-    "coffee-script": "^1.10.0",
+    "ncp": "^2.0.0",
     "run-waterfall": "^1.1.1"
   }
 }

--- a/test/fixtures/basic/package.json
+++ b/test/fixtures/basic/package.json
@@ -4,6 +4,7 @@
     "run-series": "^1.1.1"
   },
   "devDependencies": {
+    "coffee-script": "^1.10.0",
     "run-waterfall": "^1.1.1"
   }
 }


### PR DESCRIPTION
I'm not sure there's a good reason that `node_modules/.bin` should be packaged along with the rest of the app. Besides, it breaks if you use NPM 3 and `--prune` (for why, see https://github.com/maxogden/electron-packager/issues/180#issuecomment-152897559).

This should fix #149 and #180.