### PR TITLE
Don't include default_app

### DIFF
--- a/common.js
+++ b/common.js
@@ -80,6 +80,9 @@ module.exports = {
       },
       function (cb) {
         ncp(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: true}, cb)
+      },
+      function (cb) {
+        rimraf(path.join(tempPath, 'resources', 'default_app'), cb);
       }
     ]
 

--- a/common.js
+++ b/common.js
@@ -82,7 +82,7 @@ module.exports = {
         ncp(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: true}, cb)
       },
       function (cb) {
-        rimraf(path.join(tempPath, 'resources', 'default_app'), cb);
+        rimraf(path.join(tempPath, 'resources', 'default_app'), cb)
       }
     ]
 

--- a/common.js
+++ b/common.js
@@ -64,6 +64,7 @@ module.exports = {
     var tempPath = path.join(tempParent, generateFinalBasename(opts))
     // Path to `app` directory
     var appPath = path.join(tempPath, appRelativePath)
+    var resourcesPath = path.resolve(appPath, '..')
 
     var operations = [
       function (cb) {
@@ -82,7 +83,7 @@ module.exports = {
         ncp(opts.dir, appPath, {filter: userIgnoreFilter(opts), dereference: true}, cb)
       },
       function (cb) {
-        rimraf(path.join(tempPath, 'resources', 'default_app'), cb)
+        rimraf(path.join(resourcesPath, 'default_app'), cb)
       }
     ]
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -69,7 +69,10 @@ function createDefaultsTest (combination) {
       }, function (equal, cb) {
         t.true(equal,
           'File under subdirectory of packaged app directory should match source file and not be ignored by default')
-        cb()
+        fs.exists(path.join(resourcesPath, 'default_app'), function (exists) {
+          t.false(exists, 'The output directory should not contain the Electron default app')
+          cb()
+        })
       }
     ], function (err) {
       t.end(err)


### PR DESCRIPTION
It should not be necessary to include Electron's default_app. (I've only tested this on Linux so far)

Fixes #49

Thanks for electron-packager!