### PR TITLE
Don't use console.error to print info message "Packaging app for plat…

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function createSeries (opts, archs, platforms) {
         ]
 
         function createApp (comboOpts) {
-          console.error('Packaging app for platform', platform + ' ' + arch, 'using electron v' + version)
+          console.log('Packaging app for platform', platform + ' ' + arch, 'using electron v' + version)
           series(operations, function () {
             require(supportedPlatforms[platform]).createApp(comboOpts, tmpDir, callback)
           })


### PR DESCRIPTION
In my tests I check process error output and throws error if there is one. In any case I don't see any reason to use here "console.error" — I suppose, it is a typo.