### PR TITLE
Convert app-version and build-version to be cross-platform arguments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,8 +214,8 @@ If the file extension is omitted, it is auto-completed to the correct extension 
   - `LegalCopyright`
   - `FileDescription`
   - `OriginalFilename`
-  - `FileVersion`
-  - `ProductVersion`
+  - `FileVersion` (**deprecated** and will be removed in a future major version, please use the top-level `build-version` parameter instead)
+  - `ProductVersion` (**deprecated** and will be removed in a future major version, please use the top-level `app-version` parameter instead)
   - `ProductName`
   - `InternalName`
 

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ packager(opts, function done (err, appPath) { })
 
 `app-version` - *String*
 
-  The release version of the application.
+  The release version of the application. Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.
 
 `asar` - *Boolean*
 
@@ -163,7 +163,7 @@ packager(opts, function done (err, appPath) { })
 
 `build-version` - *String*
 
-  The build version of the application (OS X only).
+  The build version of the application. Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on OS X.
 
 `cache` - *String*
 

--- a/usage.txt
+++ b/usage.txt
@@ -38,7 +38,7 @@ version-string     should contain a hash of the application metadata to be embed
                    - LegalCopyright
                    - FileDescription
                    - OriginalFilename
-                   - FileVersion
-                   - ProductVersion
+                   - FileVersion (deprecated, use --build-version instead)
+                   - ProductVersion (deprecated, use --app-version instead)
                    - ProductName
                    - InternalName

--- a/usage.txt
+++ b/usage.txt
@@ -19,7 +19,7 @@ asar               packages the source code within your app into an archive
 asar-unpack        unpacks the files to app.asar.unpacked directory whose filenames regex .match this string
 asar-unpack-dir    unpacks the dir to app.asar.unpacked directory whose names match this string. It's relative to the <sourcedir>.
                    For example, `--asar-unpack-dir=sub_dir` will unpack the directory `/<sourcedir>/sub_dir`.
-build-version      build version to set for the app (darwin platform only)
+build-version      build version to set for the app
 cache              directory of cached Electron downloads. Defaults to '$HOME/.electron'
 helper-bundle-id   bundle identifier to use in the app helper plist (darwin platform only)
 icon               the icon file to use as the icon for the app. Note: Format depends on platform.

--- a/win32.js
+++ b/win32.js
@@ -23,11 +23,15 @@ module.exports = {
             if (opts['version-string']) {
               rcOpts['version-string'] = opts['version-string']
 
-              if (opts['version-string'].FileVersion) {
+              if (opts['build-version']) {
+                rcOpts['file-version'] = opts['build-version']
+              } else if (opts['version-string'].FileVersion) {
                 rcOpts['file-version'] = opts['version-string'].FileVersion
               }
 
-              if (opts['version-string'].ProductVersion) {
+              if (opts['app-version']) {
+                rcOpts['product-version'] = opts['app-version']
+              } else if (opts['version-string'].ProductVersion) {
                 rcOpts['product-version'] = opts['version-string'].ProductVersion
               }
             }


### PR DESCRIPTION
`app-version` and `build-version` take precedence over `version-string.ProductVersion` and `version-string.FileVersion`, respectively.

Closes #170. (Well, obsoletes it.)

## Open Question(s)

* [x] Do we get rid of the `version-string` way of setting these values? (and obviously, increment the major version)? In my option, there should only be one (obvious) way to do it. Plus, it's documented in the readme what properties `{app,build}-version` set for the various target OSes.