### PR TITLE
adds `tmpdir` option to fix #203

### DIFF
--- a/common.js
+++ b/common.js
@@ -60,7 +60,7 @@ module.exports = {
     // * Prunes non-production node_modules (if opts.prune is set)
     // * Creates an asar (if opts.asar is set)
 
-    var tempParent = path.join(os.tmpdir(), 'electron-packager', opts.platform + '-' + opts.arch)
+    var tempParent = path.join(opts.tmpdir || os.tmpdir(), 'electron-packager', opts.platform + '-' + opts.arch)
     var tempPath = path.join(tempParent, generateFinalBasename(opts))
     // Path to `app` directory
     var appPath = path.join(tempPath, appRelativePath)

--- a/index.js
+++ b/index.js
@@ -23,30 +23,6 @@ var supportedPlatforms = {
   win32: './win32'
 }
 
-var tempBase = path.join(os.tmpdir(), 'electron-packager')
-
-function testSymlink (cb) {
-  var testPath = path.join(tempBase, 'symlink-test')
-  var testFile = path.join(testPath, 'test')
-  var testLink = path.join(testPath, 'testlink')
-  series([
-    function (cb) {
-      mkdirp(testPath, cb)
-    },
-    function (cb) {
-      fs.writeFile(testFile, '', cb)
-    },
-    function (cb) {
-      fs.symlink(testFile, testLink, cb)
-    }
-  ], function (err) {
-    var result = !err
-    rimraf(testPath, function () {
-      cb(result) // ignore errors on cleanup
-    })
-  })
-}
-
 function validateList (list, supported, name) {
   // Validates list of architectures or platforms.
   // Returns a normalized array if successful, or an error message string otherwise.
@@ -91,6 +67,30 @@ function getNameAndVersion (opts, dir, cb) {
 }
 
 function createSeries (opts, archs, platforms) {
+  var tempBase = path.join(opts.tmpdir || os.tmpdir(), 'electron-packager')
+
+  function testSymlink (cb) {
+    var testPath = path.join(tempBase, 'symlink-test')
+    var testFile = path.join(testPath, 'test')
+    var testLink = path.join(testPath, 'testlink')
+    series([
+      function (cb) {
+        mkdirp(testPath, cb)
+      },
+      function (cb) {
+        fs.writeFile(testFile, '', cb)
+      },
+      function (cb) {
+        fs.symlink(testFile, testLink, cb)
+      }
+    ], function (err) {
+      var result = !err
+      rimraf(testPath, function () {
+        cb(result) // ignore errors on cleanup
+      })
+    })
+  }
+
   var combinations = []
   archs.forEach(function (arch) {
     platforms.forEach(function (platform) {

--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,10 @@ If the file extension is omitted, it is auto-completed to the correct extension 
 
   Whether SSL certificates are required to be valid when downloading Electron. **Defaults to `true`**.
 
+`tmpdir` - *String*
+
+  The base directory to use as a temp directory. Defaults to the system temp directory.
+
 `version` - *String*
 
   The Electron version with which the app is built (without the leading 'v') - for example, [`0.33.9`](https://github.com/atom/electron/releases/tag/v0.33.9). See [Electron releases](https://github.com/atom/electron/releases) for valid versions. If omitted, it will use the version of the nearest local installation of electron-prebuilt.

--- a/test/basic.js
+++ b/test/basic.js
@@ -312,6 +312,32 @@ function createInferTest (combination) {
   }
 }
 
+function createTmpdirTest (combination) {
+  return function (t) {
+    t.timeoutAfter(config.timeout)
+
+    var opts = Object.create(combination)
+    opts.name = 'basicTest'
+    opts.dir = path.join(__dirname, 'fixtures', 'basic')
+    opts.out = 'dist'
+    opts.tmpdir = path.join(util.getWorkCwd(), 'tmp')
+
+    waterfall([
+      function (cb) {
+        packager(opts, cb)
+      }, function (paths, cb) {
+        fs.stat(path.join(opts.tmpdir, 'electron-packager'), cb)
+      },
+      function (stats, cb) {
+        t.true(stats.isDirectory(), 'The expected temp directory should exist')
+        cb()
+      }
+    ], function (err) {
+      t.end(err)
+    })
+  }
+}
+
 util.testAllPlatforms('infer test', createInferTest)
 util.testAllPlatforms('defaults test', createDefaultsTest)
 util.testAllPlatforms('out test', createOutTest)
@@ -325,3 +351,4 @@ util.testAllPlatforms('ignore test: string with slash', createIgnoreTest, 'ignor
 util.testAllPlatforms('ignore test: only match subfolder of app', createIgnoreTest, 'electron-packager',
   path.join('electron-packager', 'readme.txt'))
 util.testAllPlatforms('overwrite test', createOverwriteTest)
+util.testAllPlatforms('tmpdir test', createTmpdirTest)

--- a/usage.txt
+++ b/usage.txt
@@ -30,6 +30,7 @@ prune              runs `npm prune --production` on the app
 sign               should contain the identity to be used when running `codesign` (only for building for the darwin platform, on OS X)
 strict-ssl         whether SSL certificates are required to be valid when downloading Electron.
                    It defaults to true, use --strict-ssl=false to disable checks.
+tmpdir             temp directory. Defaults to system temp directory.
 version-string     should contain a hash of the application metadata to be embedded into the executable (win32 platform only).
                    These can be specified on the command line via dot notation,
                    e.g. --version-string.CompanyName="Company Inc." --version-string.ProductName="Product"


### PR DESCRIPTION
Custom temporary directory can be supplied in `opts.tmpdir` or from the command line switch `--tmpdir`.  This address issue #203.