### PR TITLE
Allow ignore to be a Function

### DIFF
--- a/common.js
+++ b/common.js
@@ -30,22 +30,34 @@ function generateFinalPath (opts) {
 }
 
 function userIgnoreFilter (opts) {
+  var ignore = opts.ignore || []
+  var ignoreFunc = null
+
+  if (typeof (ignore) === 'function') {
+    ignoreFunc = function (file) { return !ignore(file) }
+  } else {
+    if (!Array.isArray(ignore)) ignore = [ignore]
+
+    ignoreFunc = function filterByRegexes (file) {
+      for (var i = 0; i < ignore.length; i++) {
+        if (file.match(ignore[i])) {
+          return false
+        }
+      }
+
+      return true
+    }
+  }
+
   return function filter (file) {
-    file = file.split(path.resolve(opts.dir))[1]
+    var name = file.split(path.resolve(opts.dir))[1]
 
     if (path.sep === '\\') {
       // convert slashes so unix-format ignores work
-      file = file.replace(/\\/g, '/')
+      name = name.replace(/\\/g, '/')
     }
 
-    var ignore = opts.ignore || []
-    if (!Array.isArray(ignore)) ignore = [ignore]
-    for (var i = 0; i < ignore.length; i++) {
-      if (file.match(ignore[i])) {
-        return false
-      }
-    }
-    return true
+    return ignoreFunc(name)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -187,10 +187,14 @@ module.exports = function packager (opts, cb) {
       err.message = 'Unable to infer name or version. Please specify a name and version.\n' + err.message
       return cb(err)
     }
+
     // Ignore this and related modules by default
     var defaultIgnores = ['/node_modules/electron-prebuilt($|/)', '/node_modules/electron-packager($|/)', '/\.git($|/)', '/node_modules/\\.bin($|/)']
-    if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
-    opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
+
+    if (typeof (opts.ignore) !== 'function') {
+      if (opts.ignore && !Array.isArray(opts.ignore)) opts.ignore = [opts.ignore]
+      opts.ignore = (opts.ignore) ? opts.ignore.concat(defaultIgnores) : defaultIgnores
+    }
 
     series(createSeries(opts, archs, platforms), function (err, appPaths) {
       if (err) return cb(err)

--- a/readme.md
+++ b/readme.md
@@ -177,9 +177,9 @@ packager(opts, function done (err, appPath) { })
 
 If the file extension is omitted, it is auto-completed to the correct extension based on the platform, including when `--platform=all` is in effect.
 
-`ignore` - *RegExp*
+`ignore` - *RegExp* or *Function*
 
-  A pattern which specifies which files to ignore when copying files to create the package(s).
+  A pattern which specifies which files to ignore when copying files to create the package(s). Alternatively, this can be a predicate function that, given the file path, returns true if the file should be ignored or false if the file should be kept.
 
 `name` - *String*
   The application name. If omitted, it will use the "productName" or "name" of the nearest package.json.

--- a/test/basic.js
+++ b/test/basic.js
@@ -346,6 +346,7 @@ util.testAllPlatforms('prune test', createPruneTest)
 util.testAllPlatforms('ignore test: string in array', createIgnoreTest, ['ignorethis'], 'ignorethis.txt')
 util.testAllPlatforms('ignore test: string', createIgnoreTest, 'ignorethis', 'ignorethis.txt')
 util.testAllPlatforms('ignore test: RegExp', createIgnoreTest, /ignorethis/, 'ignorethis.txt')
+util.testAllPlatforms('ignore test: Function', createIgnoreTest, function (file) { return file.match(/ignorethis/) }, 'ignorethis.txt')
 util.testAllPlatforms('ignore test: string with slash', createIgnoreTest, 'ignore/this',
   path.join('ignore', 'this.txt'))
 util.testAllPlatforms('ignore test: only match subfolder of app', createIgnoreTest, 'electron-packager',


### PR DESCRIPTION
This PR allows the `ignore` option to be a Function as well as a Regexp