### PR TITLE
Add NEWS.md, a human-readable list of changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ Here are some things to keep in mind as you file pull requests to fix bugs, add 
 * One of the philosophies of the project is to keep the code base as small as possible. If you are
   adding a new feature, think about whether it is appropriate to go into a separate Node module,
   and then be integrated into this project.
+* If you are contributing a nontrivial change, please add an entry to `NEWS.md`. The format is
+  similar to the one described at [Keep a Changelog](http://keepachangelog.com/).
 * Please make sure your commits are rebased onto the latest commit in the master branch, and that
   you limit/squash the number of commits created to a "feature"-level. For instance:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,59 @@
+# Changes by Version
+
+## Unreleased
+
+### Added
+
+* Add support for a new target platform, Mac App Store (`mas`) (#223)
+* Add `app-copyright` parameter (#223)
+* Add `tmpdir` parameter to specify a custom temp directory (#230)
+* Add `NEWS.md`, a human-readable list of changes in each version (since 5.2.0) (#263)
+
+### Changed
+
+* Allow the `ignore` parameter to take a function (#247)
+* [contributors] Update Standard (JavaScript coding standard) package to 5.4.x
+* [contributors] Add code coverage support via Coveralls (#257)
+* Better docs around contributing to the project (#258)
+
+### Fixed
+
+* [darwin] Ensure `CFBundleVersion` and `CFBundleShortVersionString` are strings (#250)
+* [darwin] Correctly set the helper bundle ID in all relevant plist files (#223)
+
+## [5.2.1] - 2016-01-17
+
+### Changed
+
+* [win32] Add support for Windows for the `app-version` and `build-version` parameters (#229)
+* If `appname` and/or `version` are omitted from the parameters, infer from `package.json` (#94)
+
+### Deprecated
+
+* [win32] `version-string.FileVersion` and `version-string.ProductVersion` are deprecated in
+  favor of `app-version` and `build-version`, respectively (#229)
+
+### Fixed
+
+* Remove `default_app` from built packages (#206)
+* Add documentation for optional arguments (#226)
+* [darwin] Don't declare helper app as a protocol handler (#220)
+
+## [5.2.0] - 2015-12-16
+
+### Added
+
+* Add `asar-unpack-dir` parameter (#174)
+* [darwin] Add `app-category-type` parameter (#202)
+* Add `strict-ssl` parameter (#209)
+
+### Changed
+
+* Ignore `node_modules/.bin` by default (#189)
+
+----
+
+For versions prior to 5.2.0, please see `git log`.
+
+[5.2.1]: https://github.com/maxogden/electron-packager/compare/v5.2.0...v5.2.1
+[5.2.0]: https://github.com/maxogden/electron-packager/compare/v5.1.1...v5.2.0


### PR DESCRIPTION
As mentioned in https://github.com/maxogden/electron-packager/issues/235#issuecomment-170384955 and https://github.com/maxogden/electron-packager/pull/223#issuecomment-183989800.

Only contains changes from 5.2.0 onward. If someone else wants to backfill, feel free :grin: 