### PR TITLE
fix: copyTemplate failed if tmpdir set to false

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -153,10 +153,27 @@ export class App {
   async copyTemplate() {
     await promisifyHooks(this.opts.beforeCopy, this.hookArgsWithOriginalResourcesAppDir);
 
-    await fs.copy(this.opts.dir, this.originalResourcesAppDir, {
-      filter: userPathFilter(this.opts),
-      dereference: this.opts.derefSymlinks,
-    });
+    if (this.opts.tmpdir === false) {
+      const filter = userPathFilter(this.opts);
+      const items = await fs.readdir(this.opts.dir);
+      await Promise.all(items.map(async item => {
+        const srcItem = path.join(this.opts.dir, item);
+        const destItem = path.join(this.originalResourcesAppDir, item);
+
+        const include = await filter(srcItem, destItem);
+        if (!include) return;
+
+        return fs.copy(srcItem, destItem, {
+          filter,
+          dereference: this.opts.derefSymlinks ?? true,
+        });
+      }));
+    } else {
+      await fs.copy(this.opts.dir, this.originalResourcesAppDir, {
+        filter: userPathFilter(this.opts),
+        dereference: this.opts.derefSymlinks ?? true,
+      });
+    }
     await promisifyHooks(this.opts.afterCopy, this.hookArgsWithOriginalResourcesAppDir);
     if (this.opts.prune) {
       await promisifyHooks(this.opts.afterPrune, this.hookArgsWithOriginalResourcesAppDir);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

if tmpdir set to false, `fs-extra copy` api will throw a error that `Cannot copy 'xxx' to a subdirectory of itself, 'xxx/out/xxx'.`

so we cant call `fs.copy` in this case, traverse first-level directories to call `fs.copy` instead