### PR TITLE
chore: ignore fixtures from socket while making them uninstallable

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,4 +1,4 @@
 version: 2
 
 projectIgnorePaths:
-- "test/fixtures/basic"
+- "test/fixtures/*"

--- a/test/fixtures/.npmrc
+++ b/test/fixtures/.npmrc
@@ -1,0 +1,3 @@
+offline=true
+registry=http://localhost:0
+ignore-scripts=true

--- a/test/fixtures/.yarnrc.yml
+++ b/test/fixtures/.yarnrc.yml
@@ -1,0 +1,3 @@
+npmRegistryServer: "http://localhost:0"
+enableNetwork: false
+enableImmutableInstalls: true


### PR DESCRIPTION
Cleans up a bunch of warnings in socket from old electron versions that we don't _actually_ depend on