### PR TITLE
fix: allow `tmpdir` to be true

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -93,8 +93,15 @@ export function isPlatformMac(
   return platform === 'darwin' || platform === 'mas';
 }
 
+/**
+ * Gets the tmpdir for packaging. Note that if `opts.tmpdir` is false,
+ * we're still returning a path.
+ */
 export function baseTempDir(opts: Options) {
-  return path.join(opts.tmpdir || os.tmpdir(), 'electron-packager');
+  return path.join(
+    typeof opts.tmpdir === 'string' ? opts.tmpdir : os.tmpdir(),
+    'electron-packager',
+  );
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -581,9 +581,11 @@ export interface Options {
   quiet?: boolean;
   /**
    * The base directory to use as a temporary directory. Set to `false` to disable use of a
-   * temporary directory. Defaults to the system's temporary directory.
+   * temporary directory.
+   *
+   * @defaultValue Uses the system's temporary directory if `true` or `undefined`.
    */
-  tmpdir?: string | false;
+  tmpdir?: string | boolean;
   /**
    * Human-readable descriptions of how the Electron app uses certain macOS features. These are displayed
    * in the App Store. A non-exhaustive list of available properties:


### PR DESCRIPTION
We defaulted `tmpdir` to be true in https://github.com/electron/packager/pull/1834/, but the types and code only accepted `string` and `false` values.

This PR changes it so that `true` is equal to `undefined` in this case. This should fix the canary job that's been failing for a while.