### PR TITLE
ci: allow `canary.yml` to be called manually

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,6 +3,7 @@ name: electron-nightly Canary
 on:
   schedule:
     - cron: "15 8 * * *"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
ref https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow