### PR TITLE
fix: force release

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "build:docs": "npx typedoc",
     "lint": "prettier --check \"*.{ts,js,json}\" && eslint src --cache",
     "prepack": "npm run build",
-    "pretest": "npm run build",
     "test": "vitest run",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Creates a new release after #1849 landed.

Also removes the `pretest` lifecycle script that doesn't apply to Yarn Berry. We don't need to build ahead of time with Vitest, so there's no need to keep the script there.