### PR TITLE
ci: fix cache path in canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,6 +24,7 @@ jobs:
           # electron/minimal-repro doesn't have a .nvmrc file
           node-version: lts/*
           cache: 'npm'
+          cache-dependency-path: minimal-repro/package-lock.json
       - name: Replace electron with electron-nightly
         run: |
           cd minimal-repro


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Because we're checking out `minimal-repro` into a subdir, this needs to be updated to point at it.