### PR TITLE
fix: throw when package name is set to `electron`

### DIFF
--- a/src/packager.ts
+++ b/src/packager.ts
@@ -367,6 +367,12 @@ export async function packager(opts: Options): Promise<string[]> {
     );
   }
 
+  if (processedOpts.name === 'electron') {
+    throw new Error(
+      'Application names cannot be set to "electron" due to limitations on macOS',
+    );
+  }
+
   debug(`Application name: ${processedOpts.name}`);
   debug(`Target Electron version: ${processedOpts.electronVersion}`);
 

--- a/test/packager.spec.ts
+++ b/test/packager.spec.ts
@@ -35,6 +35,19 @@ describe('packager', () => {
     );
   });
 
+  it('cannot build apps where the name is equal to "electron"', async ({
+    baseOpts,
+  }) => {
+    const opts = {
+      ...baseOpts,
+      name: 'electron',
+    };
+
+    await expect(packager(opts)).rejects.toThrowError(
+      'Application names cannot be set to "electron" due to limitations on macOS',
+    );
+  });
+
   it.for([
     {
       electronVersion: '0.0.1',


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
throw when package name is set to `electron`.
tested with leading and trailing whitespaces too for potential `.trim()` but this problem only happens when it's just `electron`

fixes #1869 