### PR TITLE
fix: ensure ASAR integrity buffer on windows is valid

### DIFF
--- a/src/resedit.ts
+++ b/src/resedit.ts
@@ -153,10 +153,16 @@ export async function resedit(exePath: string, options: ExeMetadata) {
       alg: options.asarIntegrity![file].algorithm,
       value: options.asarIntegrity![file].hash,
     }));
+
+    const integrityBuffer = Buffer.from(JSON.stringify(integrityList), 'utf-8');
+
     res.entries.push({
       type: 'INTEGRITY',
       id: 'ELECTRONASAR',
-      bin: Buffer.from(JSON.stringify(integrityList), 'utf-8').buffer,
+      bin: integrityBuffer.buffer.slice(
+        integrityBuffer.byteOffset,
+        integrityBuffer.byteOffset + integrityBuffer.length,
+      ),
       lang: languageInfo[0].lang,
       codepage: languageInfo[0].codepage,
     });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This pull request fixes #1873 which was caused by the change in 8d64aa1777af1c714f7c9cd67aae7b132635e7fe to `resedit.js` where `.buffer` was added when setting the data for the integrity resource resulting in it being written corruptly to the final `exe`.

The documentation for [Buffer.buffer](https://nodejs.org/api/buffer.html#bufbuffer) warns the result "is not guaranteed to correspond exactly to the original Buffer". This not corresponding exactly to the original buffer seems to be what is resulting in the corrupt integrity data as reverting that change results in the correct data being written to the resource and Electron starting as expected with integrity checking enabled.

It does make me wonder if the other uses of `.buffer` could be causing issues but I did not revert the other `.buffer` as it seems to be just matching up with behavior above it.