### PR TITLE
fix: allow folders in extra-resource (#1852)

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -394,6 +394,7 @@ export class App {
             this.resourcesDir,
             path.basename(resource),
           ),
+          { recursive: true },
         ),
       ),
     );


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Allow the `extraResource` field to accept folders. Fixes #1852.

As mentioned in #1852, since using `graceful-fs`'s `fs.promises.cp` without options to copy `extraResource`, it can no longer copy folders. However, the [document](https://packages.electronjs.org/packager/v19.0.3/interfaces/Options.html#extraresource) does not specify that the `extraResource` field cannot accept folders. Moreover, in versions [v18.4.4](https://www.npmjs.com/package/@electron/packager/v/18.4.4) and earlier, it could also accept folders. Therefore, I believe this fix is appropriate.
