### PR TITLE
build: drop redundant npx prefixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           path: ~/.cache/electron
           key: v1-electron-cache-${{ matrix.os }}
       - name: Download Electron binaries
-        run: npx tsx test/ci/download-electron.ts
+        run: yarn tsx test/ci/download-electron.ts
       - name: Lint
         run: yarn run lint
       - name: Test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npx lint-staged
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "build:docs": "npx typedoc",
+    "build:docs": "typedoc",
     "lint": "prettier --check \"*.{ts,js,json}\" && eslint src --cache",
     "prepack": "npm run build",
     "test": "vitest run",


### PR DESCRIPTION
typedoc, lint-staged, and tsx are all devDependencies — `npx` is redundant.

- `package.json`: `npx typedoc` → `typedoc`
- `.husky/pre-commit`: `npx lint-staged` → `yarn lint-staged`
- `.github/workflows/test.yml`: `npx tsx` → `yarn tsx`