### PR TITLE
chore(ci): group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,18 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+  groups:
+    # Creates a separate PR for each non-security-related major update.
+    major-version-updates:
+      applies-to: "version-updates"
+      group-by: "dependency-name"
+      update-types: ["major"]
+
+    # Creates a single PR with all non-security-related minor/patch updates.
+    non-major-version-updates:
+      applies-to: "version-updates"
+      update-types: ["minor", "patch"]
+
+    # Creates a single PR with all security-related updates.
+    security-updates:
+      applies-to: "security-updates"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,22 @@ updates:
     # Creates a single PR with all security-related updates.
     security-updates:
       applies-to: "security-updates"
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  groups:
+    # Creates a separate PR for each non-security-related major update.
+    major-version-updates:
+      applies-to: "version-updates"
+      group-by: "dependency-name"
+      update-types: ["major"]
+
+    # Creates a single PR with all non-security-related minor/patch updates.
+    non-major-version-updates:
+      applies-to: "version-updates"
+      update-types: ["minor", "patch"]
+
+    # Creates a single PR with all security-related updates.
+    security-updates:
+      applies-to: "security-updates"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     # Creates a single PR with all security-related updates.
     security-updates:
       applies-to: "security-updates"
-      update-types: ["minor", "patch"]
+      update-types: ["major", "minor", "patch"]
 - package-ecosystem: "npm"
   directory: "/"
   schedule:
@@ -39,4 +39,4 @@ updates:
     # Creates a single PR with all security-related updates.
     security-updates:
       applies-to: "security-updates"
-      update-types: ["minor", "patch"]
+      update-types: ["major", "minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,23 +20,3 @@ updates:
     security-updates:
       applies-to: "security-updates"
       update-types: ["major", "minor", "patch"]
-- package-ecosystem: "npm"
-  directory: "/"
-  schedule:
-    interval: "monthly"
-  groups:
-    # Creates a separate PR for each non-security-related major update.
-    major-version-updates:
-      applies-to: "version-updates"
-      group-by: "dependency-name"
-      update-types: ["major"]
-
-    # Creates a single PR with all non-security-related minor/patch updates.
-    non-major-version-updates:
-      applies-to: "version-updates"
-      update-types: ["minor", "patch"]
-
-    # Creates a single PR with all security-related updates.
-    security-updates:
-      applies-to: "security-updates"
-      update-types: ["major", "minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
     # Creates a single PR with all security-related updates.
     security-updates:
       applies-to: "security-updates"
+      update-types: ["minor", "patch"]
 - package-ecosystem: "npm"
   directory: "/"
   schedule:
@@ -38,3 +39,4 @@ updates:
     # Creates a single PR with all security-related updates.
     security-updates:
       applies-to: "security-updates"
+      update-types: ["minor", "patch"]


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [X] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* [X] The changes have sufficient test coverage (if applicable).
* [X] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This creates three separate [groups](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates) for Dependabot updates ~~across the `github-actions` and `npm` package ecosystems~~ for the `github-actions` ecosystem so that we can get fewer PRs with multiple dependencies each, both for security fixes and for regular, scheduled version bumps:

- `major-version-updates`: every scheduled non-security major bump gets a separate PR (same as today): it's easier to fix breaking changes if there's only one variable to consider. (We might want to remove this group if we're using an older version of some package in order to reduce noise for dependencies we can't update for whatever reason)
- `non-major-version-updates`: all scheduled non-security minor/patch updates are grouped in one big PR updating them all: I think this is especially useful for the scheduled monthly updates, as it would significantly reduce the noise from multiple nearly-simultaneous PRs
- `security-updates`: all security updates (major/minor/patch, though in practice most are minor/patch) are grouped in one big PR updating them all: useful in cases where multiple packages are compromised as a result of the same attack or multiple unrelated patches come out at roughly the same time. For one-off updates, we still get a PR with only one dependency bump. Security updates are not subject to the same monthly schedule as regular dependency bumps and should still be made available right away.

