### PR TITLE
docs: remove CoC reference from contributing md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,6 @@ contributions. They include, but are not limited to:
 We strongly suggest that before filing an issue, you search through the existing issues to see
 if it has already been filed by someone else.
 
-This project is a part of the Electron ecosystem. As such, all contributions to this project follow
-[Electron's code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md)
-where appropriate.
-
 ## Before opening bug reports/technical issues
 
 ### Debugging


### PR DESCRIPTION
Given that [the CoC document is up to date in the `.github` repository](https://github.com/electron/.github/pull/53), this reference should be removed so that the  `.github` CoC is the only one visible and mentioned in this repository.

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:** Removed Code of Conduction mention from CONTRIBUTING.md

