### PR TITLE
fix: declare osxSign.continueOnError in PackagerOsxSignOptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -133,13 +133,22 @@ export type FinalizePackageTargetsHookFunction = (
   targets: TargetDefinition[],
 ) => void | Promise<void>;
 
-/** See the documentation for [`@electron/osx-sign`](https://npm.im/@electron/osx-sign#opts) for details.
- * @interface
+/**
+ * See the documentation for [`@electron/osx-sign`](https://npm.im/@electron/osx-sign#opts) for details.
  */
-export type PackagerOsxSignOptions = Omit<
+export interface PackagerOsxSignOptions extends Omit<
   OSXSignOptions,
   'app' | 'binaries' | 'platform' | 'version'
->;
+> {
+  /**
+   * Whether to keep packaging (and print a warning) when signing fails. Set this to `false` to
+   * make a signing failure fail the packaging run instead. Packager handles this option itself,
+   * `@electron/osx-sign` has no equivalent.
+   *
+   * @defaultValue `true`
+   */
+  continueOnError?: boolean;
+}
 
 /**
  * See the documentation for [`@electron/universal`](https://github.com/electron/universal)
@@ -177,6 +186,14 @@ export interface MacOSProtocol {
  * for details.
  */
 export interface PackagerWindowsSignOptions extends Omit<WindowsSignOptions, 'appDirectory'> {
+  /**
+   * Whether to keep packaging (and print a warning) when signing fails. Unlike
+   * {@link PackagerOsxSignOptions.continueOnError}, a signing failure fails the packaging run unless
+   * this is set to `true`. Packager handles this option itself, `@electron/windows-sign` has no
+   * equivalent.
+   *
+   * @defaultValue `false`
+   */
   continueOnError?: boolean;
 }
 

--- a/test/mac.spec.ts
+++ b/test/mac.spec.ts
@@ -1,4 +1,5 @@
 import { createNotarizeOpts, createSignOpts, filterCFBundleIdentifier } from '../src/mac.js';
+import type { PackagerOsxSignOptions } from '../src/types.js';
 import { describe, it, expect } from 'vitest';
 
 describe('createNotarizeOpts', () => {
@@ -57,9 +58,9 @@ describe('createSignOpts', () => {
   });
 
   it('passes in continueOnError=false', () => {
-    const args: Partial<ReturnType<typeof createSignOpts>> = {
-      continueOnError: false,
-    };
+    // Typed as the public option type on purpose: continueOnError has to be
+    // declared there, or users can't set it without a cast.
+    const args: PackagerOsxSignOptions = { continueOnError: false };
     const signOpts = createSignOpts(args, 'darwin', 'out', 'version');
     expect(signOpts.continueOnError).toBe(false);
   });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`createSignOpts` has read `osxSign.continueOnError` since #1579 (and defaults it to `true`), but `PackagerOsxSignOptions` is a straight `Omit<>` of osx-sign's options so from TypeScript you can only set it through a cast (the existing test for it has to type its args as `Partial<ReturnType<typeof createSignOpts>>` for the same reason, and we're carrying a cast for it in the desktop app's forge config). `PackagerWindowsSignOptions` already declares it, this just does the same on the mac side.

While there I documented the field on both, mainly because the defaults differ: mac defaults to `true` (warn and carry on), windows to `false` (nothing sets it so a signing failure throws), which isn't obvious from either type.

The `continueOnError=false` test now types its args as `PackagerOsxSignOptions`, so it doubles as the regression test: on main that line is a TS2353. `yarn build:docs` still builds, the alias just becomes a real interface (dropping the `@interface` tag typedoc needed for the alias).
